### PR TITLE
feat(bills): Add offset argument to methods with range argument

### DIFF
--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,7 +1,15 @@
+from enum import Enum
+
 class SortOrder:
     NONE = 0
     ASC = 1
     DESC = 2
+
+class Range(Enum):
+    ONE_MONTH = 1
+    THREE_MONTHS = 3
+    SIX_MONTHS = 6
+    ONE_YEAR = 12
 
 categoryColors = {
             "Electricity": "#FFA500",


### PR DESCRIPTION
- Offset argument is used to display bills for previous ranges. Example: For 1 month range, and offset 2, method will get bills between 1 month and 2 months ago, instead of between current date and 1 month ago. Offset's default value is 1.
- Create new enum Range class for range values: 1 month, 3 months, 6 months, and 1 year
- Refactor private method __rangeClause to use new enum Range class and add offset argument